### PR TITLE
Ed25519 support & fixes

### DIFF
--- a/ssh-hostkeys2sshfp
+++ b/ssh-hostkeys2sshfp
@@ -14,11 +14,12 @@ fqdn=$1
 cipher1='rsa'
 cipher2='dsa'
 cipher3='ecdsa'
+cipher4='ed25519'
 
 hash1='sha1'
 hash2='sha256' 
 
-for i in `seq 1 3` # cipher
+for i in `seq 1 4` # cipher
 do
   for j in `seq 1 2` # hash
   do

--- a/ssh-keyscan2sshfp
+++ b/ssh-keyscan2sshfp
@@ -9,7 +9,7 @@ echo "Should not be used unless you can really trust your"
 echo "network... but who can?!?"
 echo "####################################################"
 
-sigs=`ssh-keyscan -t ecdsa,dsa,rsa $* 2> /dev/null`
+sigs=`ssh-keyscan -t ecdsa,dsa,rsa,ed25519 $* 2> /dev/null`
 
 while IFS= read -r line; do
   echo $line | grep -E '^#' > /dev/null
@@ -19,8 +19,8 @@ while IFS= read -r line; do
 
   host=`echo -n $line | awk '{print $1}'`
   algo=`echo -n $line | awk '{print $2}'`
-  sig_sha1=`echo -n $line | awk '{print $3}' | openssl base64 -d -A | openssl dgst -sha1 | awk '{print $1}' | tr '[a-z]' '[A-Z]'`
-  sig_sha2=`echo -n $line | awk '{print $3}' | openssl base64 -d -A | openssl dgst -sha | awk '{print $1}' | tr '[a-z]' '[A-Z]'`
+  sig_sha1=`echo -n $line | awk '{print $3}' | openssl base64 -d -A | openssl dgst -sha1 -r | awk '{print $1}' | tr '[a-z]' '[A-Z]'`
+  sig_sha2=`echo -n $line | awk '{print $3}' | openssl base64 -d -A | openssl dgst -sha256 -r | awk '{print $1}' | tr '[a-z]' '[A-Z]'`
 
   case "$algo" in
     'ssh-rsa')
@@ -31,6 +31,9 @@ while IFS= read -r line; do
       ;;
     'ecdsa-sha2-nistp256')
       algo="3"
+      ;;
+    'ssh-ed25519')
+      algo="4"
       ;;
   esac
 


### PR DESCRIPTION
ed25519 algorithm should be type 4:
https://www.iana.org/assignments/dns-sshfp-rr-parameters/dns-sshfp-rr-parameters.xml

Fixes in ssh-keyscan2sshfp:
Added -r to openssl dgst parameters so that print{1} after is ok
Changed -sh to -sha256 (see RFC6594).

Now, "ssh-keyscan2sshfp localhost" and "ssh-hostkeys2sshfp localhost" returns the same value \o/